### PR TITLE
Prepend and append newlines around the user's script when wrapping fo…

### DIFF
--- a/src/gateway/core/vm/vm.go
+++ b/src/gateway/core/vm/vm.go
@@ -134,7 +134,7 @@ func (c *CoreVM) RunWithStop(script interface{}) (value otto.Value, stop bool, e
 func WrapJSComponent(c *CoreVM, script string) (string, func() (bool, error)) {
 	stopVal := "8a52973428f63bb0135a3abf535fec0f15b4c8eda1e9a2f1431f0a1f759babd3"
 	resultVar := "__exec_result"
-	wrapped := fmt.Sprintf("var stop = '%s'; var %s = (function() {%s})();", stopVal, resultVar, script)
+	wrapped := fmt.Sprintf("var stop = '%s'; var %s = (function() {\n%s\n})();", stopVal, resultVar, script)
 
 	fn := func() (bool, error) {
 		v, err := c.Get(resultVar)


### PR DESCRIPTION
…r stop functionality. This should prevent trailing comments on the final line of a script from causing an unexpected error.