### PR TITLE
[Finishes #138536135] Added AP.Crypto.rand function to the VM.

### DIFF
--- a/src/gateway/core/core.go
+++ b/src/gateway/core/core.go
@@ -263,6 +263,7 @@ var shared = func() *otto.Otto {
 	conversion.IncludePath(vm)
 	crypto.IncludeHashing(vm)
 	crypto.IncludeAes(vm)
+	crypto.IncludeRand(vm)
 	encoding.IncludeEncoding(vm)
 
 	return vm

--- a/src/gateway/core/vm/crypto/rand.go
+++ b/src/gateway/core/vm/crypto/rand.go
@@ -1,0 +1,57 @@
+package crypto
+
+import (
+	"crypto/rand"
+	b64 "encoding/base64"
+	"gateway/logreport"
+
+	corevm "gateway/core/vm"
+
+	"github.com/robertkrimen/otto"
+)
+
+// IncludeRand adds the AP.Crypto.rand function to the VM.
+func IncludeRand(vm *otto.Otto) {
+	setRand(vm)
+
+	scripts := []string{
+		"var AP = AP || {};",
+		"AP.Crypto = AP.Crypto || {};",
+		"AP.Crypto.rand = _rand; delete _rand;",
+	}
+
+	for _, s := range scripts {
+		vm.Run(s)
+	}
+}
+
+func setRand(vm *otto.Otto) {
+	vm.Set("_rand", func(call otto.FunctionCall) otto.Value {
+		n, err := corevm.GetArgument(call, 0)
+		if err != nil {
+			logreport.Println(err)
+			return otto.UndefinedValue()
+		}
+
+		number, ok := n.(int64)
+		if !ok {
+			logreport.Println("number of bytes should be an integer")
+			return otto.UndefinedValue()
+		}
+
+		b := make([]byte, number)
+		_, err = rand.Read(b)
+		if err != nil {
+			logreport.Println(err)
+			return otto.UndefinedValue()
+		}
+
+		val, err := vm.ToValue(b64.StdEncoding.EncodeToString(b))
+		if err != nil {
+			logreport.Println(err)
+			return otto.UndefinedValue()
+		}
+
+		return val
+	})
+}

--- a/src/gateway/core/vm/crypto/rand.go
+++ b/src/gateway/core/vm/crypto/rand.go
@@ -41,7 +41,7 @@ func setRand(vm *otto.Otto) {
 
 		if number > 4096 {
 			number = 4096
-			logreport.Println("maximum of 1024 random bytes")
+			logreport.Println("maximum of 4096 random bytes")
 		}
 
 		b := make([]byte, number)

--- a/src/gateway/core/vm/crypto/rand.go
+++ b/src/gateway/core/vm/crypto/rand.go
@@ -39,6 +39,11 @@ func setRand(vm *otto.Otto) {
 			return otto.UndefinedValue()
 		}
 
+		if number > 4096 {
+			number = 4096
+			logreport.Println("maximum of 1024 random bytes")
+		}
+
 		b := make([]byte, number)
 		_, err = rand.Read(b)
 		if err != nil {

--- a/src/gateway/core/vm/vm_test.go
+++ b/src/gateway/core/vm/vm_test.go
@@ -31,6 +31,10 @@ func (s *VMSuite) TestExtensionsIncluded(c *gc.C) {
 		get:         "AP.Crypto",
 		expectClass: "Object",
 	}, {
+		should:      "include AP.Crypto.rand",
+		get:         "AP.Crypto.rand",
+		expectClass: "Function",
+	}, {
 		should:      "include AP.Crypto.encrypt",
 		get:         "AP.Crypto.encrypt",
 		expectClass: "Function",


### PR DESCRIPTION
The only argument for the function is the number of random bytes to return.

```javascript
var bytes = AP.Crypto.rand(32);
```

Results are base64 encoded for ease of consumption/handling.