### PR TITLE
Hostname is always the default proxy domain root for MQTT right now s…

### DIFF
--- a/src/gateway/core/mqtt.go
+++ b/src/gateway/core/mqtt.go
@@ -224,7 +224,7 @@ func (c *Core) ExecuteMQTT(context fmt.Stringer, logPrint logreport.Logf, msg *m
 						"response.size":                 responseSize,
 						"response.status":               responseCode,
 						"response.error":                errResponse,
-						"host.id":                       request.Host,
+						"host.id":                       0,
 						"host.name":                     request.Host,
 						"proxy.id":                      proxyEndpoint.ID,
 						"proxy.name":                    proxyEndpoint.Name,


### PR DESCRIPTION
…o use 0 as the hostID.